### PR TITLE
Make test helpers private to clean up documentation

### DIFF
--- a/source/either.d
+++ b/source/either.d
@@ -274,23 +274,23 @@ unittest {
 }
 
 version(unittest) {
-  alias TestEither = Either!(int, Exception);
+  private alias TestEither = Either!(int, Exception);
 }
 
 version(unittest) {
-  bool alwaysTrue(bool) {
+  private bool alwaysTrue(bool) {
     return true;
   }
 
-  bool alwaysTrueInt(int) {
+  private bool alwaysTrueInt(int) {
     return true;
   }
 
-  bool alwaysFalse(bool) {
+  private bool alwaysFalse(bool) {
     return false;
   }
 
-  bool alwaysFalseInt(int) {
+  private bool alwaysFalseInt(int) {
     return false;
   }
 }


### PR DESCRIPTION
On my local version or adrdox, this works to hide the test helpers in the docs, but I don't know how the program is invoked for the documentation generated for dub packages.

If you want, I will also make all the other helpers that aren't part of the public API private to clean up the docs further.